### PR TITLE
Fix compatibility issue with RTFM framework, add cpu info to svd file

### DIFF
--- a/resources/STM32F40x.svd
+++ b/resources/STM32F40x.svd
@@ -5,6 +5,16 @@ xs:noNamespaceSchemaLocation="CMSIS-SVD_Schema_1_1.xsd">
   <name>STM32F40x</name>
   <version>1.5</version>
   <description>STM32F40x</description>
+  <cpu>
+    <name>CM4</name>
+    <revision>r1p1</revision>
+    <endian>little</endian>
+    <fpuPresent>true</fpuPresent>
+    <mpuPresent>false</mpuPresent>
+    <vtorPresent>true</vtorPresent>
+    <nvicPrioBits>4</nvicPrioBits>
+    <vendorSystickConfig>false</vendorSystickConfig>
+  </cpu>
   <!--Bus Interface Properties-->
   <!--Cortex-M4 is byte addressable-->
   <addressUnitBits>8</addressUnitBits>


### PR DESCRIPTION
Adds cpu info section in the svd file. This section was also added manually in https://github.com/japaric/stm32f103xx

This is needed by the RTFM framework, see error bellow on a blinky project:
```
error[E0425]: cannot find value `NVIC_PRIO_BITS` in module `stm32f40x`
  --> examples/blinky_rtfm.rs:18:1
   |
18 | / app! {
19 | |     device: stm32f40x,
20 | |
21 | |     resources: {
...  |
30 | |     },
31 | | }
   | |_^ not found in `stm32f40x`
```

